### PR TITLE
[TASK] Load mode style inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,22 @@ A list of objects describing map layers. Each object has at least `name`, `url` 
 
 #### mode (string)
 
-Allows to load a additional style for a night mode or similar use case. Style is attached to the mapLayer.
+Allows to load a additional style for a night mode or similar use case. Possible are inline style or link. 
+Inline avoids re-rendering and maybe issues with label-layer update. Important are class "css-mode mode-name" and media "not".
+
+_Default is night.css inline in index.html_
+
+```html
+ <link rel="stylesheet" class="css-mode mode-name" media="not" href="mode-name.css">
+```
+
+or
+
+```html
+<style class="css-mode mode-name" media="not">
+   <inline src="mode-name.css" />
+</style>
+```
 
 #### start (integer)
 

--- a/html/index.html
+++ b/html/index.html
@@ -3,7 +3,10 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-  <link rel="stylesheet" href="style.css?__build=true">
+  <link rel="stylesheet" href="main.css?__build=true">
+  <style class="css-mode night" media="not">
+    <inline src="night.css" />
+  </style>
   <script>
     var jsonData = <inline src="config.json" />;
   </script>

--- a/lib/map.js
+++ b/lib/map.js
@@ -330,25 +330,15 @@ define(['map/clientlayer', 'map/labelslayer',
         if (map.getZoom() > map.options.maxZoom) {
           map.setZoom(map.options.maxZoom);
         }
-        if (helper.localStorageTest()) {
-          localStorage.setItem('map/selectedLayer', JSON.stringify({ name: e.name }));
-        }
 
-        var cssMode = document.querySelector('.css-mode');
-        if (cssMode) {
-          cssMode.parentNode.removeChild(cssMode);
-          document.querySelector('html').className = '';
+        var style = document.querySelector('.css-mode:not([media="not"])');
+        if (style && e.layer.options.mode !== '' && !style.classList.contains(e.layer.options.mode)) {
+          style.media = 'not';
           labelsLayer.updateLayer();
         }
         if (e.layer.options.mode) {
-          document.querySelector('head').innerHTML += "<link rel='stylesheet' class='css-mode' href='" + e.layer.options.mode + ".css'>";
-          document.querySelector('html').classList.add(e.layer.options.mode);
-          var cssInterval = setInterval(function () {
-            if (typeof document.querySelector('.css-mode').sheet.cssRules !== 'undefined') {
-              labelsLayer.updateLayer();
-              clearInterval(cssInterval);
-            }
-          }, 10);
+          document.querySelector('.css-mode.' + e.layer.options.mode).media = '';
+          labelsLayer.updateLayer();
         }
       });
 

--- a/scss/night.scss
+++ b/scss/night.scss
@@ -5,7 +5,7 @@
 $color-white: #111;
 $color-black: #fefefe;
 
-.night {
+html {
   //@import 'modules/base';
   body {
     background: $color-white;

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -42,24 +42,37 @@ module.exports = function exports(grunt) {
       }
     },
     sass: {
+      files: [{
+        expand: true,
+        cwd: 'scss/',
+        src: '*.scss',
+        dest: 'build/',
+        ext: '.css'
+      }],
       dev: {
         options: {
           sourceMap: true,
           outputStyle: 'expanded'
         },
-        files: {
-          'build/style.css': 'scss/main.scss',
-          'build/night.css': 'scss/night.scss'
-        }
+        files: [{
+          expand: true,
+          cwd: 'scss/',
+          src: '*.scss',
+          dest: 'build/',
+          ext: '.css'
+        }]
       },
       dist: {
         options: {
           outputStyle: 'compressed'
         },
-        files: {
-          'build/style.css': 'scss/main.scss',
-          'build/night.css': 'scss/night.scss'
-        }
+        files: [{
+          expand: true,
+          cwd: 'scss/',
+          src: '*.scss',
+          dest: 'build/',
+          ext: '.css'
+        }]
       }
     },
     postcss: {

--- a/tasks/clean.js
+++ b/tasks/clean.js
@@ -4,7 +4,7 @@ module.exports = function exports(grunt) {
   grunt.config.merge({
     clean: {
       build: ['build/**/*', 'node_modules/grunt-newer/.cache'],
-      release: ['build/vendor', 'build/*.map', 'build/config.json', 'build/style.css']
+      release: ['build/vendor', 'build/*.map', 'build/config.json', 'build/main.css']
     }
   });
 


### PR DESCRIPTION
Why?
Inline overhead is minimal and currently only known mode is night mode. Maybe a April fools day can be added, but in general to switch complete style is normally not the use case. Also link implementation still works, but the label color issue is back (tries to read the label-color from css, but value isn't updated/loaded).

Usage:
```html
 <link rel="stylesheet" class="css-mode night" media="not" href="night.css"> 
```
or
```html
<style class="css-mode night" media="not">
   <inline src="night.css" />
</style>
```
Advantage(s):
- Less JS code, setTimeout loop and dynamic link tags.
- No visible color switch is gone.

Disadvantage:
Night style is shipped by default (even without any mode).