### PR TITLE
[TASK] Replace deprecated moment.js function

### DIFF
--- a/lib/utils/language.js
+++ b/lib/utils/language.js
@@ -35,18 +35,20 @@ define(['polyglot', 'moment', 'helper'], function (Polyglot, moment, helper) {
     function setTranslation(json) {
       _.extend(json);
 
-      moment.locale(_.locale(), {
-        longDateFormat: {
-          LT: 'HH:mm',
-          LTS: 'HH:mm:ss',
-          L: 'DD.MM.YYYY',
-          LL: 'D. MMMM YYYY',
-          LLL: 'D. MMMM YYYY HH:mm',
-          LLLL: 'dddd, D. MMMM YYYY HH:mm'
-        },
-        calendar: json.momentjs.calendar,
-        relativeTime: json.momentjs.relativeTime
-      });
+      if (moment.locale(_.locale()) !== _.locale()) {
+        moment.defineLocale(_.locale(), {
+          longDateFormat: {
+            LT: 'HH:mm',
+            LTS: 'HH:mm:ss',
+            L: 'DD.MM.YYYY',
+            LL: 'D. MMMM YYYY',
+            LLL: 'D. MMMM YYYY HH:mm',
+            LLLL: 'dddd, D. MMMM YYYY HH:mm'
+          },
+          calendar: json.momentjs.calendar,
+          relativeTime: json.momentjs.relativeTime
+        });
+      }
     }
 
     window._ = new Polyglot({ locale: getLocale(), allowMissing: true });


### PR DESCRIPTION
<!--- Use a prefix like [TASK], [BUGFIX], [DOC] or [CGL] and provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
moment.locale() returns always the current locale after setting it. If the locale wasn't found it stays/returns default 'en'. No nice getter or nice check for existing locale.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/ffrgb/meshviewer/issues/96

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)