### PR TITLE
[BUGFIX] select node from nodelist in forcegraph

### DIFF
--- a/lib/forcegraph.js
+++ b/lib/forcegraph.js
@@ -200,13 +200,12 @@ define(['d3-selection', 'd3-force', 'd3-zoom', 'd3-drag', 'utils/math', 'forcegr
       };
 
       self.gotoNode = function gotoNode(d) {
-        draw.setHighlight({ type: 'node', o: d });
-
         for (var i = 0; i < intNodes.length; i++) {
           var n = intNodes[i];
-          if (n.o.node !== d) {
+          if (n.o.node.nodeinfo.node_id !== d.nodeinfo.node_id) {
             continue;
           }
+          draw.setHighlight({ type: 'node', o: n.o.node });
           transform.k = (ZOOM_MAX + 1) / 2;
           moveTo(n.x, n.y);
           break;


### PR DESCRIPTION
If somebody show the forcegraph, go to the nodelist on the sidebar and select a node.
the sidebar change -> but not on the forcegraph.

The problem is, that at https://github.com/ffrgb/meshviewer/blob/59a73a3fb5a68173e55dedbc53eef40d84425113/lib/nodelist.js#L97 a copy of the node object was created and so it is not possible to check direct the equalize of objects.
So we should check the `node_id`