### PR TITLE
[TASK] Travis nodejs v8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: node_js
 
 node_js:
-  - "7"
+  - "8"
 
 os:
   - linux
@@ -12,7 +12,7 @@ os:
 
 matrix:
   include:
-  - node_js: 7
+  - node_js: 8
     os: linux
     env: USE_NPM=true
   - node_js: 6

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ _Some similar features might have been implemented/merged_
   - Currently available: en, de, fr & ru
 - Gulp inline for some css and js - fewer requests and instant load indicator
 - Icon font with needed icons only
-- Switch to Gulp (Tested with Node.js 4/6 LTS, 7 on Linux, 7 OSX & W**)
+- Switch to Gulp (Tested with Node.js 4/6 LTS, 8 on Linux, OSX & W**)
   - css and some js moved inline
 - Yarn/npm in favour of bower
   - Load only moment.js without languages (Languages are included in translations)


### PR DESCRIPTION
<!--- Use a prefix like [TASK], [BUGFIX], [DOC] or [CGL] and provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
NodeJS v8 is released - Debian strech and jessie backports using  v4
