### PR TITLE
[TASK] Support link to webpage in site info

### DIFF
--- a/lib/infobox/node.js
+++ b/lib/infobox/node.js
@@ -39,15 +39,30 @@ define(['sorttable', 'snabbdom', 'd3-interpolate', 'moment', 'helper'],
 
     function showSite(d, config) {
       var site = helper.dictGet(d.nodeinfo, ['system', 'site_code']);
-      var rt = site;
+      var name = site;
+      var link;
+
       if (config.siteNames) {
         config.siteNames.forEach(function (t) {
           if (site === t.site) {
-            rt = t.name;
+            name = t.name;
+            link = t.link;
           }
         });
       }
-      return rt;
+
+      return function (el) {
+        if (typeof link === 'undefined') {
+          var e = document.createTextNode(name);
+          el.appendChild(e);
+        } else {
+          var a = document.createElement('a');
+          a.href = link;
+          a.target = '_blank';
+          a.textContent = name;
+          el.appendChild(a);
+        }
+      };
     }
 
     function showUptime(d) {


### PR DESCRIPTION
Hi,

several communities might share a map. In this case it is useful to provide a link to the respective community web site.
This patch allows to add a link field in the siteNames info of the config.json file and makes the site entry a link.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
