### PR TITLE
[TASK] Hide stats title when table is empty

### DIFF
--- a/lib/proportions.js
+++ b/lib/proportions.js
@@ -178,14 +178,16 @@ define(['d3-interpolate', 'snabbdom', 'filters/genericnode', 'helper'],
       };
 
       self.renderSingle = function renderSingle(el, heading, table) {
-        var h2 = document.createElement('h2');
-        h2.classList.add('proportion-header');
-        h2.textContent = _.t(heading);
-        h2.onclick = function onclick() {
-          table.elm.classList.toggle('hide');
-        };
-        el.appendChild(h2);
-        el.appendChild(table.elm);
+        if (table.children.length > 0) {
+          var h2 = document.createElement('h2');
+          h2.classList.add('proportion-header');
+          h2.textContent = _.t(heading);
+          h2.onclick = function onclick() {
+            table.elm.classList.toggle('hide');
+          };
+          el.appendChild(h2);
+          el.appendChild(table.elm);
+        }
       };
       return self;
     };


### PR DESCRIPTION
Our community does not have "Auto update" or "Gateway" information.
The empty sections with the title only look like a bug.
It is better not to show them if no information is available.

## Checklist:
- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [-] My change requires a change to the documentation.
