### PR TITLE
[BUGFIX] Allow missing site

### DIFF
--- a/lib/infobox/node.js
+++ b/lib/infobox/node.js
@@ -45,7 +45,7 @@ define(['sorttable', 'snabbdom', 'd3-interpolate', 'moment', 'helper'],
           }
         });
       }
-      return rt;
+      return rt || undefined;
     }
 
     function showUptime(d) {


### PR DESCRIPTION
A node might not provide a site value. "Site: null" would be displayed in that case.
This PR will hide the site if it is not present.