### PR TITLE
[BUGFIX] Center link arrow

### DIFF
--- a/lib/infobox/link.js
+++ b/lib/infobox/link.js
@@ -21,6 +21,7 @@ define(['helper'], function (helper) {
 
     var arrow = document.createElement('span');
     arrow.classList.add('ion-arrow-right-c');
+    arrow.style.verticalAlign = 'middle';
     h2.appendChild(arrow);
 
     var a2 = document.createElement('a');


### PR DESCRIPTION
The link arrow is not properly centered. Not sure if this should go into some CSS file..