### PR TITLE
[TASK] show gateways in row (for longer names)

### DIFF
--- a/lib/infobox/node.js
+++ b/lib/infobox/node.js
@@ -35,26 +35,29 @@ define(['sorttable', 'snabbdom', 'd3-interpolate', 'moment', 'helper', 'utils/no
       }
 
       function showGateway(node) {
-        var gatewayCols = [
+        var gatewayRows = [
+          V.h('div', [
+            'IPv4 ',
+            nodeIdLink(node.gateway)
+          ])
+        ];
+        if (node.gateway6 !== undefined) {
+          gatewayRows.push(V.h('div', [
+            'IPv6 ',
+            nodeIdLink(node.gateway6)
+          ]));
+        }
+        var gatewayValue = [
           V.h('span', [
             nodeIdLink(node.gateway_nexthop),
             V.h('br'),
             _.t('node.nexthop')
           ]),
           V.h('span', { props: { className: 'ion-arrow-right-c' } }),
-          V.h('span', [
-            nodeIdLink(node.gateway),
-            V.h('br'),
-            'IPv4'
-          ]),
-          V.h('span', [
-            nodeIdLink(node.gateway6),
-            V.h('br'),
-            'IPv6'
-          ])
+          V.h('span', gatewayRows)
         ];
 
-        return V.h('td', { props: { className: 'gateway' } }, gatewayCols);
+        return V.h('td', { props: { className: 'gateway' } }, gatewayValue);
       }
 
       function renderNeighbourRow(n) {


### PR DESCRIPTION
1. on this way, there is no design break if the gateways- and nexthop-names are to long.
2. hide ipv6 gateway, if not given (gluon-radvd-filter is not official released https://github.com/freifunk-gluon/gluon/pull/838)
![screenshot from 2017-11-09 19-30-26](https://user-images.githubusercontent.com/6905586/32623198-a0dd490e-c585-11e7-801b-23462a8bb7eb.png)
