### PR TITLE
[TASK] more space on small mobile devices and right padding on large

### DIFF
--- a/scss/modules/_table.scss
+++ b/scss/modules/_table.scss
@@ -22,6 +22,12 @@ table {
   }
 }
 
+@media screen and (max-width: map-get($grid-breakpoints, sm) - 1) {
+  table{
+    padding: 0 7px 0 3px;
+  }
+}
+
 td,
 th {
   line-height: 1.41em;
@@ -29,6 +35,14 @@ th {
 
   &:first-child {
     text-align: left;
+  }
+}
+
+
+@media screen and (min-width: map-get($grid-breakpoints, sm)) {
+  table.node-list td,
+  table.node-links td{
+    padding-right: 1em;
   }
 }
 


### PR DESCRIPTION
<!--- Use a prefix like [TASK], [BUGFIX], [DOC] or [CGL] and provide a general summary of your changes in the Title above -->

## Description
change the style of node-list and node-links so the text is positioned more underneath the title icon. (only on larger devices than $grid-breakpoint sm: 544px) on smaller devices the padding of all lists is minimaized to get more space for the content.

## Motivation and Context
in the old style the numbers are below the (invisible) arrow, which doesn't look right.

## How Has This Been Tested?
locally tested with `gulp serve`

## Screenshots/links (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
