### PR TITLE
[BUGFIX] Allow negative coordinates

### DIFF
--- a/lib/utils/router.js
+++ b/lib/utils/router.js
@@ -85,7 +85,7 @@ define(['Navigo'], function (Navigo) {
     var router = new Navigo(null, true);
 
     router
-      .on(/^\/?#?\/([\w]{2})?\/?(map|graph)?\/?([a-f\d]{12})?([a-f\d\-]{25})?\/?(?:(\d+)\/([\d.]+)\/([\d.]+))?$/, customRoute)
+      .on(/^\/?#?\/([\w]{2})?\/?(map|graph)?\/?([a-f\d]{12})?([a-f\d\-]{25})?\/?(?:(\d+)\/(-?[\d.]+)\/(-?[\d.]+))?$/, customRoute)
       .on({
         '*': function () {
           router.fullUrl();


### PR DESCRIPTION
Signed-off-by: Felix Kaechele <felix@kaechele.ca>

## Description
This allows deeplinks to have negative coordinates. Also fixes the
coordinate picker when selecting coordinates with negative values.

## Motivation and Context
The world is more than just the part east of the prime meridian and
north of the equator 😜

## How Has This Been Tested?
Tested in Firefox 58 on Fedora 27.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
