### PR TITLE
[TASK] allow 'iframe' config option to use interactive stats instead of static image

### DIFF
--- a/lib/utils/helper.js
+++ b/lib/utils/helper.js
@@ -117,7 +117,15 @@ define({
     }
   },
   showStat: function showStat(V, o, subst) {
-    var content = V.h('img', { attrs: { src: require('helper').listReplace(o.image, subst) } });
+    var content = '';
+    if (o.iframe) {
+      content = V.h('iframe', { attrs: { src: require('helper').listReplace(o.iframe, subst), width: '100%', height: '350px' } });
+      if (o.href) {
+        delete o.href;
+      }
+    } else {
+      content = V.h('img', { attrs: { src: require('helper').listReplace(o.image, subst) } });
+    }
 
     if (o.href) {
       return V.h('p', V.h('a', {


### PR DESCRIPTION

## Description
Add an 'iframe' config option to allow embedding grafana stats

## Motivation and Context
Embedding the stats looks nicer than a static image

## How Has This Been Tested?
Here's a test site:
https://hopglass.freifunk-niersufer.de/meshviewer/#/de/map/14cc2097d3dc

## Screenshots/links (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (How?)
