### PR TITLE
[TASK] Allow empty uptime fields

### DIFF
--- a/lib/nodelist.js
+++ b/lib/nodelist.js
@@ -4,6 +4,9 @@ define(['sorttable', 'snabbdom', 'helper'], function (SortTable, V, helper) {
 
   function showUptime(uptime) {
     // 1000ms are 1 second and 60 second are 1min: 60 * 1000 =  60000
+    if (isNaN(uptime)) {
+      return '-';
+    }
     var s = uptime / 60000;
     if (Math.abs(s) < 60) {
       return Math.round(s) + ' m';
@@ -28,6 +31,9 @@ define(['sorttable', 'snabbdom', 'helper'], function (SortTable, V, helper) {
     name: 'node.uptime',
     class: 'ion-time',
     sort: function (a, b) {
+      if (isNaN(a.uptime) || isNaN(b.uptime)) {
+        return isNaN(a.uptime) - isNaN(b.uptime);
+      }
       return a.uptime - b.uptime;
     },
     reverse: true


### PR DESCRIPTION
Not all our nodes send their uptime as part of a privacy policy (only transfer essential node data by default).

This breaks the nodelist and apparently cannot be fixed using the config.default.js.