### PR TITLE
[TASK] Visualize mesh link directions

### DIFF
--- a/lib/map/labellayer.js
+++ b/lib/map/labellayer.js
@@ -2,6 +2,137 @@ define(['leaflet', 'rbush', 'helper', 'moment'],
   function (L, rbush, helper, moment) {
     'use strict';
 
+    /* This function call extends leaflet's polyline to support arrows 
+     * It is based on leaflet-textpath
+     */
+    (function () {
+      var __onAdd = L.Polyline.prototype.onAdd;
+      var __onRemove = L.Polyline.prototype.onRemove;
+      var __updatePath = L.Polyline.prototype._updatePath;
+      var __bringToFront = L.Polyline.prototype.bringToFront;
+
+      var PolylineArrowsPath = {
+        onAdd: function (map) {
+          __onAdd.call(this, map);
+          this._arrowsRedraw();
+        },
+
+        onRemove: function (map) {
+          map = map || this._map;
+          if (map && this._arrowsNode && map._renderer._container) {
+            map._renderer._container.removeChild(this._arrowsNode);
+          }
+          __onRemove.call(this, map);
+        },
+
+        bringToFront: function () {
+          __bringToFront.call(this);
+          this._arrowsRedraw();
+        },
+
+        _updatePath: function () {
+          __updatePath.call(this);
+          this._arrowsRedraw();
+        },
+
+        _arrowsRedraw: function () {
+          var options = this._arrowsOptions;
+          this.removeArrows().addArrows(options);
+        },
+
+        removeArrows: function () {
+          if (this._arrowsNode && this._arrowsNode.parentNode) {
+            this._map._renderer._container.removeChild(this._arrowsNode);
+
+            /* delete the node, so it will not be removed a 2nd time if the layer is later removed from the map */
+            delete this._arrowsNode;
+          }
+          return this;
+        },
+
+        addArrows: function (options) {
+          /* First arrow 18 unbreakable spaces after line begin.
+           * pattern repeats every 18+18+1=37 characters
+           */
+          var text = '\u00A0'.repeat(18) + '►' + '\u00A0'.repeat(18);
+
+          /* If not in SVG mode or Polyline not added to map yet return */
+          /* addArrows will be called by onAdd */
+          if (!L.Browser.svg || typeof this._map === 'undefined') {
+            return this;
+          }
+
+          var defaults = {
+            repeat: true,
+            attributes: {},
+            below: false
+          };
+
+          options = L.Util.extend(defaults, options);
+
+          var id = 'pathdef-' + L.Util.stamp(this);
+          var svg = this._map._renderer._container;
+          this._path.setAttribute('id', id);
+
+          /* Initially compute single pattern length */
+          if (typeof this._arrowlen === 'undefined') {
+            var pattern = L.SVG.create('text');
+            for (var attr in options.attributes) {
+              pattern.setAttribute(attr, options.attributes[attr]);
+            }
+            pattern.appendChild(document.createTextNode(text));
+            svg.appendChild(pattern);
+            this._arrowlen = pattern.getComputedTextLength();
+            svg.removeChild(pattern);
+          }
+
+          /* Create string as long as path */
+          text = new Array(Math.ceil(this._path.getTotalLength() / this._arrowlen)).join(text);
+
+          /* Put it along the path using textPath */
+          var arrowsNode = L.SVG.create('text');
+          var arrowsPath = L.SVG.create('textPath');
+          var dy = options.offset || this._path.getAttribute('stroke-width');
+
+          arrowsPath.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', '#' + id);
+          arrowsNode.setAttribute('dy', dy);
+
+          /* Inherit color of polyline */
+          arrowsNode.setAttribute('fill', this._path.getAttribute('stroke'));
+
+          for (var at in options.attributes) {
+            arrowsNode.setAttribute(at, options.attributes[at]);
+          }
+          arrowsPath.appendChild(document.createTextNode(text));
+          arrowsNode.appendChild(arrowsPath);
+          this._arrowsNode = arrowsNode;
+
+          svg.appendChild(arrowsNode);
+          
+          /* Center arrows according to the path's bounding box */
+          var arrowsLength = arrowsNode.getComputedTextLength();
+          var pathLength = this._path.getTotalLength();
+          /* Set the position for the left side of the arrowsNode */
+          arrowsNode.setAttribute('dx', ((pathLength / 2) - (arrowsLength / 2)));
+
+          return this;
+        }
+      };
+
+      L.Polyline.include(PolylineArrowsPath);
+
+      L.LayerGroup.include({
+        addArrows: function (options) {
+          for (var layer in this._layers) {
+            if (typeof this._layers[layer].addArrows === 'function') {
+              this._layers[layer].addArrows(options);
+            }
+          }
+          return this;
+        }
+      });
+    })();
+
     var groupOnline;
     var groupOffline;
     var groupNew;
@@ -101,14 +232,31 @@ define(['leaflet', 'rbush', 'helper', 'moment'],
       });
 
       return graph.map(function (d) {
+        var dash = 'none';
+        var coord = d.latlngs;
+        var arrows = false;
+
+        if (typeof d.source_best !== 'undefined') {
+          if (!(d.source_best || d.target_best)) {
+            dash = '20,20';
+          } else if (!(d.source_best && d.target_best)) {
+            coord = (d.source_best && !d.target_best) ? coord : coord.reverse();
+            arrows = true;
+          }
+        }
+
         var opts = {
           color: linkScale((d.source_tq + d.target_tq) / 2),
           weight: 4,
           opacity: 0.5,
-          dashArray: 'none'
+          dashArray: dash
         };
 
-        var line = L.polyline(d.latlngs, opts);
+        var line = L.polyline(coord, opts);
+
+        if (arrows) {
+          line.addArrows();
+        }
 
         line.resetStyle = function resetStyle() {
           line.setStyle(opts);

--- a/lib/map/labellayer.js
+++ b/lib/map/labellayer.js
@@ -2,7 +2,7 @@ define(['leaflet', 'rbush', 'helper', 'moment'],
   function (L, rbush, helper, moment) {
     'use strict';
 
-    /* This function call extends leaflet's polyline to support arrows 
+    /* This function call extends leaflet's polyline to support arrows
      * It is based on leaflet-textpath
      */
     (function () {
@@ -108,7 +108,7 @@ define(['leaflet', 'rbush', 'helper', 'moment'],
           this._arrowsNode = arrowsNode;
 
           svg.appendChild(arrowsNode);
-          
+
           /* Center arrows according to the path's bounding box */
           var arrowsLength = arrowsNode.getComputedTextLength();
           var pathLength = this._path.getTotalLength();


### PR DESCRIPTION
## Description
This commit adds two additional visualizations for mesh links on the map:
 - If the link is neither being used by the source nor the destination node the polyline is dashed
 - If the link is being used by e.g. the source node, but not by the destination node the polyline has arrows pointing to the destination node

The required fields in the JSON data have not been implemented by YANIC, yet. I'm going to make a pull-request when I have time. 
It is not very elegant that I embedded the modified leaflet-textpath plugin in the labellayer.js file. I know this it not the place where it belongs. Unfortunately the original leaflet-textpath.js file's syntax does not comply with require.js syntax. Thus it is not possible to cleanly include the existing npm-package using as the resulting function would be empty and Leaflet cannot be included as a requirement. 
Thus I ask you JS-gurus to tell me how I should include it properly.

EDIT: Another thing is the performance could be improved slightly by computing the "arrowtext" length only once, but I'm not sure how to achieve that properly and if there may be any issues with dynamic resizing or something else that I've not encountered, yet.

## Motivation and Context
As described in issue #284 Gluon will introduce the "best" field in respondd data from which it can be derived whether a specific mesh link is actually being used. 

## How Has This Been Tested?
Not, yet.

## Screenshots/links (if appropriate):

## Checklist:
- [ ] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
