### PR TITLE
[TASK] shorten model for commonly used manufactors.

### DIFF
--- a/lib/proportions.js
+++ b/lib/proportions.js
@@ -96,7 +96,19 @@ define(['d3-interpolate', 'snabbdom', 'utils/version', 'filters/genericnode', 'h
           return d ? 'online' : 'offline';
         });
         var fwDict = count(nodes, ['firmware', 'release']);
-        var hwDict = count(nodes, ['model']);
+        var replHw = ['tp-link ', 'ubiquiti nanostation ', 'ubiquiti ', 'nanostation', 'linksys '];
+        var hwDict = count(nodes, ['model'], function (d) {
+          if (!d) {
+            return d;
+          }
+          for (var i in replHw) {
+            var k = replHw[i];
+            if (d.toLowerCase().startsWith(k)) {
+              return d.slice(k.length);
+            }
+          }
+          return d;
+        });
         var geoDict = count(nodes, ['location'], function (d) {
           return d && d.longitude && d.latitude ? _.t('yes') : _.t('no');
         });


### PR DESCRIPTION
The hardware model names are quite long with manufacture, so the name of the models is often too long for one line and you see line breaks within the hardware model in statistiscs. This patch removes the manufactor for commonly known manufactors.

See http://karte.leipzig.freifunk.net:8018/meshviewer2/build/ where this patch is already rolled out.